### PR TITLE
Fix the HttpHandleOptions Not Found Exception

### DIFF
--- a/examples/http.ts
+++ b/examples/http.ts
@@ -4,7 +4,7 @@ import { json, http } from "../assembly";
 
 let handle: http.HttpHandle | null = http.HttpOpen(
   "http://httpbin.org/anything",
-  new http.HttpHandleOptions("GET")
+  new http.HttpOptions("GET")
 );
 
 if (handle != null) {


### PR DESCRIPTION
Quick fix for one compile exception in the examples directory.

Environment as follow:
```
node --version && npm --version
v18.10.0
9.6.1
```

Exception as follow:
```
asc examples/http.ts --target release
ERROR TS2339: Property 'HttpHandleOptions' does not exist on type 'http'.
   :
 7 │ new http.HttpHandleOptions("GET")
   │          ~~~~~~~~~~~~~~~~~
   └─ in examples/http.ts(7,12)

FAILURE 1 compile error(s)
```