### PR TITLE
Feature/eng 1041 user set buffer length in sdk assemblyscript memory module

### DIFF
--- a/assembly/http/stdin.ts
+++ b/assembly/http/stdin.ts
@@ -12,7 +12,7 @@ export class HttpStdin {
         const blsStdinString = blsStdin.toString().replaceAll('\0', '').trim()
         const blsPathQuerySplit = blsStdinString.split('?')
 
-        const blsEnv = new memory.EnvVars().read()
+        const blsEnv = new memory.EnvVars(2048).read()
         const blsEnvString = blsEnv.toJSON()
 
         if (blsEnvString.has('BLS_REQUEST_METHOD')) {

--- a/assembly/memory/index.ts
+++ b/assembly/memory/index.ts
@@ -43,13 +43,16 @@ function readEnvVars(buf: Array<u8>): i32 {
 }
 
 export class Stdin {
-    buf: u8[] = new Array(1024);
-    constructor() {
+    private buf: u8[] = new Array()
+    private bufLen: i32
 
+    constructor(bufLen: i32 = 1024) {
+      this.bufLen = bufLen >= 1024 ? bufLen : 1024;
+      this.buf = new Array(this.bufLen);
     }
 
     read(): Stdin {
-        let tbuf: u8[] = new Array(1024);
+        let tbuf: u8[] = new Array(this.bufLen);
         let bs = readStdin(tbuf);
         this.buf = tbuf;
         return this;
@@ -79,13 +82,17 @@ export class Stdin {
 }
 
 export class EnvVars {
-  buf: u8[] = new Array(1024);
   private static vars: Map<string, string> | null = null;
+  private bufLen: i32
+  private buf: u8[] = new Array()
 
-  constructor() {}
+  constructor(bufLen: i32 = 1024) {
+    this.bufLen = bufLen >= 1024 ? bufLen : 1024;
+    this.buf = new Array(this.bufLen);
+  }
 
   read(): EnvVars {
-    let tbuf: u8[] = new Array(1024);
+    let tbuf: u8[] = new Array(this.bufLen);
     let bs = readEnvVars(tbuf);
     this.buf = tbuf;
     return this;


### PR DESCRIPTION
Allow user defined buffer lengths with a minimum of 1024, and increase the default EnvVars buffer length in the HTTP module to 2048. 